### PR TITLE
feat: omit empty logical operators (AND, OR, NOT) from query

### DIFF
--- a/src/lib/where.ts
+++ b/src/lib/where.ts
@@ -115,16 +115,23 @@ function handleLogicalOperator(
 	whereClauses: string[],
 ) {
 	if (operator === "NOT") {
-		whereClauses.push(
-			`NOT(${where(value as QueryWhereCondition, "AND", relations)})`,
-		);
+		const notClause = where(value as QueryWhereCondition, "AND", relations);
+		if (notClause !== "") {
+			whereClauses.push(`NOT(${notClause})`);
+		}
 		return;
 	}
 	const subWhereClauses: string[] = [];
 	for (const condition of value as QueryWhereCondition[]) {
-		subWhereClauses.push(`${where(condition, operator, relations)}`);
+		const whereClause = where(condition, operator, relations);
+		if (whereClause !== "") {
+			subWhereClauses.push(whereClause);
+		}
 	}
-	whereClauses.push(`(${subWhereClauses.join(` ${operator} `)})`);
+
+	if (subWhereClauses.length > 0) {
+		whereClauses.push(`(${subWhereClauses.join(` ${operator} `)})`);
+	}
 	return;
 }
 

--- a/src/test/where.test.ts
+++ b/src/test/where.test.ts
@@ -48,6 +48,30 @@ describe("where", () => {
 		expect(result).toBe(`NOT("id" = 1 AND "name" = 'John')`);
 	});
 
+	it("should ignore empty AND", () => {
+		const conditions: QueryWhereCondition = { id: 1, AND: [] };
+		const result = where(conditions);
+		expect(result).toBe(`"id" = 1`);
+	});
+
+	it("should ignore empty OR", () => {
+		const conditions: QueryWhereCondition = { id: 1, OR: [] };
+		const result = where(conditions);
+		expect(result).toBe(`"id" = 1`);
+	});
+
+	it("should ignore empty NOT", () => {
+		const conditions = { id: 1, NOT: {} };
+		const result = where(conditions);
+		expect(result).toBe(`"id" = 1`);
+	});
+
+	it("should ignore nested empty operators", () => {
+		const conditions = { id: 1, AND: [{ OR: [{ AND: [] }] }] };
+		const result = where(conditions);
+		expect(result).toBe(`"id" = 1`);
+	});
+
 	it("should handle different types of operators", () => {
 		// Test for greaterThan and lessThan
 		expect(where({ id: { greaterThan: 1, lessThan: 10 } })).toBe(


### PR DESCRIPTION
- Updated query builder logic to filter out invalid or missing conditions for `AND`, `OR`, and `NOT` operators.
- Logical operators are now only included in the query if their corresponding conditions array is non-empty.
- Returns an empty query or default query if no valid conditions are present for any logical operator.
- Prevents incorrect query structures like `{ AND: [], OR: [], NOT: [] }` from being generated.